### PR TITLE
Add installable entrypoint

### DIFF
--- a/run.py
+++ b/run.py
@@ -4,8 +4,8 @@
 #  Copyright (c) 2020 Constantinos Eleftheriou <Constantinos.Eleftheriou@ed.ac.uk>
 #  Distributed under the terms of the MIT Licence.
 import faulthandler  # report segmentation faults as tracebacks
-import visiomode.core
+from visiomode.main import main
 
 faulthandler.enable()
 
-visiomode.core.Visiomode()
+main()

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 from glob import glob
 
 APP = ["run.py"]
@@ -9,7 +9,8 @@ setup(
     version="0.0.1",
     app=APP,
     data_files=DATA_FILES,
-    packages=find_packages(),
+    packages=["visiomode"],
     include_package_data=True,
     install_requires=["Flask", "PyYAML"],
+    entry_points={'console_scripts': ['visiomode = visiomode.main:main']},
 )

--- a/visiomode/config.py
+++ b/visiomode/config.py
@@ -30,7 +30,7 @@ class Config(mixins.YamlAttributesMixin):
     fullscreen = False
     devices = "devices/"
 
-    def __init__(self, path=DEFAULT_PATH):
+    def __init__(self, path=None):
         """Initialises Config with a path to a configuration file.
 
         If a valid configuration file exists, the program assumes it is NOT in debug mode, unless the config file
@@ -39,4 +39,6 @@ class Config(mixins.YamlAttributesMixin):
         Args:
             path: Path to config YAML, defaults to DEFAULT_PATH. Only used if it exists.
         """
+        if not path:
+            path = DEFAULT_PATH
         self.load_yaml(path)

--- a/visiomode/core.py
+++ b/visiomode/core.py
@@ -16,9 +16,9 @@ import visiomode.protocols as protocols
 
 
 class Visiomode:
-    def __init__(self):
+    def __init__(self, config_path=None):
         self.clock = pg.time.Clock()
-        self.config = conf.Config()
+        self.config = conf.Config(config_path)
 
         self.action_q = queue.Queue()  # Queue for action messages
         self.log_q = queue.Queue()  # Queue for log messages

--- a/visiomode/main.py
+++ b/visiomode/main.py
@@ -1,0 +1,28 @@
+"""Main entry point"""
+
+#  This file is part of visiomode.
+#  Copyright (c) 2020 Constantinos Eleftheriou <Constantinos.Eleftheriou@ed.ac.uk>
+#  Distributed under the terms of the MIT Licence.
+import os
+import sys
+from pathlib import Path
+
+from visiomode import config, core
+
+
+def main():
+    """Main entry point"""
+    if len(sys.argv) > 1:
+        config_path = Path(sys.argv[1])
+        if not os.access(config_path, os.R_OK):
+            print(f"Config at '{config_path.as_posix()}' cannot be accessed.")
+            return
+
+    else:
+        config_path = Path(config.DEFAULT_PATH)
+
+    core.Visiomode(config_path)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This adds an entrypoint that is installed as an executable alongside the
package. The 'tests' folder is no longer installed with the rest of the
code.

The entrypoint can optionally be passed an argument to specify the path
to the configuration file to use instead of the default. The advantage
of this is twofold:

 - no messing in /etc
 - custom config paths make sharing a single config across machines
   easier