### PR TITLE
Pass configuration parameters to where needed

### DIFF
--- a/visiomode/config.py
+++ b/visiomode/config.py
@@ -19,18 +19,7 @@ class Config(mixins.YamlAttributesMixin):
     Defaults to development settings unless initialised with a valid path to a config YAML, or the file specified by
     DEFAULT_PATH exists.
     """
-
-    debug = True
-    flask_key = "dev"
-    data_dir = "instance/"
-
-    fps = 60
-    width = 400
-    height = 800
-    fullscreen = False
-    devices = "devices/"
-
-    def __init__(self, path=DEFAULT_PATH):
+    def __init__(self, path=None):
         """Initialises Config with a path to a configuration file.
 
         If a valid configuration file exists, the program assumes it is NOT in debug mode, unless the config file
@@ -39,4 +28,13 @@ class Config(mixins.YamlAttributesMixin):
         Args:
             path: Path to config YAML, defaults to DEFAULT_PATH. Only used if it exists.
         """
-        self.load_yaml(path)
+        self.debug = True
+        self.flask_key = "dev"
+        self.data_dir = "instance/"
+        self.fps = 60
+        self.width = 400
+        self.height = 800
+        self.fullscreen = False
+        self.devices = "devices/"
+
+        self.load_yaml(path or DEFAULT_PATH)

--- a/visiomode/core.py
+++ b/visiomode/core.py
@@ -16,9 +16,12 @@ import visiomode.protocols as protocols
 
 
 class Visiomode:
-    def __init__(self):
+    def __init__(self, config=None):
         self.clock = pg.time.Clock()
-        self.config = conf.Config()
+
+        if not config:
+            config = conf.Config()
+        self.config = config
 
         self.action_q = queue.Queue()  # Queue for action messages
         self.log_q = queue.Queue()  # Queue for log messages
@@ -26,7 +29,7 @@ class Visiomode:
         self.session = None
 
         # Initialise webpanel, run in background
-        webpanel.runserver(action_q=self.action_q, log_q=self.log_q, threaded=True)
+        webpanel.runserver(config, action_q=self.action_q, log_q=self.log_q, threaded=True)
 
         request_thread = threading.Thread(target=self.request_listener, daemon=True)
         request_thread.start()

--- a/visiomode/stimuli.py
+++ b/visiomode/stimuli.py
@@ -10,8 +10,6 @@ import pygame.math as pgm
 import visiomode.config as conf
 import visiomode.mixins as mixins
 
-config = conf.Config()
-
 
 def get_stimulus(stimulus_id):
     return Stimulus.get_child(stimulus_id)

--- a/visiomode/webpanel/__init__.py
+++ b/visiomode/webpanel/__init__.py
@@ -15,14 +15,12 @@ import visiomode.stimuli as stimuli
 import visiomode.webpanel.api as api
 
 
-def create_app(action_q=None, log_q=None):
+def create_app(config, action_q=None, log_q=None):
     """Flask app factory
 
     Returns:
         Flask app object
     """
-    config = cfg.Config()
-
     app = flask.Flask(__name__)
     app.config.from_mapping({"SECRET_KEY": config.flask_key, "DEBUG": config.debug})
 
@@ -101,9 +99,9 @@ def create_app(action_q=None, log_q=None):
     return app
 
 
-def runserver(action_q, log_q, threaded=False):
+def runserver(config, action_q, log_q, threaded=False):
     """Runs the flask app in an integrated server."""
-    app = create_app(action_q, log_q)
+    app = create_app(config, action_q, log_q)
     if threaded:
         thread = threading.Thread(
             target=app.run,
@@ -111,7 +109,7 @@ def runserver(action_q, log_q, threaded=False):
             daemon=True,
         )
         return thread.start()
-    app.run(host="0.0.0.0", debug=True)
+    app.run(host="0.0.0.0")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This lets a user use a single configuration file (that isn't the
default) and its attributes will be used elsewhere in the code.


This is a draft that only does a bit but you get the drift. It looks like the config is only used in a couple places, and with `Visiomode` mastering everything, it should be relatively simple for it to pass the information needed elsewhere along.