### PR TITLE
Fix negative frequency updating for moving gratings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Versions follow [Semantic Versioning](https://semver.org) (`<major>.<minor>.<pat
 - Remove warning about Hyperpixel display compatibility with the latest Raspberry Pi OS. This is now [fixed](https://github.com/pimoroni/hyperpixel4/issues/177).
 - Documentation migrated to mkdocs, hosted at [docs.visiomode.org](https://docs.visiomode.org).
 
+### Fixed
+
+- Negative frequencies for moving gratings stimuli now update properly ([#86](https://github.com/DuguidLab/visiomode/issues/86)).
+
 ## [0.5.2] - 2023-04-26
 
 ### Added

--- a/src/visiomode/stimuli/moving_grating.py
+++ b/src/visiomode/stimuli/moving_grating.py
@@ -1,5 +1,6 @@
 #  This file is part of visiomode.
 #  Copyright (c) 2021 Constantinos Eleftheriou <Constantinos.Eleftheriou@ed.ac.uk>
+#  Copyright (c) 2024 Olivier Delree <odelree@ed.ac.uk>
 #  Distributed under the terms of the MIT Licence.
 
 import pygame as pg

--- a/src/visiomode/stimuli/moving_grating.py
+++ b/src/visiomode/stimuli/moving_grating.py
@@ -32,7 +32,7 @@ class MovingGrating(stimuli.Stimulus):
         self.rect = self.image.get_rect()
         self.area = self.screen.get_rect()
 
-        self.orig_center = (self.rect.centerx, self.rect.centery)
+        self.orig_center = (self.rect.centerx, self.rect.centery - self.period)
 
         self.pos = pgm.Vector2(self.orig_center)
         self.velocity = pgm.Vector2(0, self.px_per_cycle)
@@ -40,7 +40,7 @@ class MovingGrating(stimuli.Stimulus):
     def update(self, timedelta=0):
         if self.hidden:
             return
-        if self.rect.bottom <= self.height:
+        if self.rect.bottom <= self.height or self.rect.top >= 0:
             self.pos = self.orig_center
         self.pos += self.velocity
         self.rect.centery = self.pos[1]


### PR DESCRIPTION
Closes #86.

This fixes the weird behaviour observed with the moving grating stimulus when providing a negative frequency.
It should now update properly on screen. Since we were using a buffer of twice the period for the grating image, I have moved the default position to be one period up and we now check for the top of the image rectangle to reset it when it passes the origin threshold.