### PR TITLE
Switch `Config` to singleton design pattern

### DIFF
--- a/src/visiomode/config.py
+++ b/src/visiomode/config.py
@@ -126,10 +126,20 @@ class Config(object):
             else:
                 logging.warning("Unknown config key: {}".format(key))
 
+        self._validate()
+
     def _set_defaults(self):
         """Sets config to default values."""
         for key, value in DEFAULT_CONFIG.items():
             setattr(self, key, value)
+
+    def _validate(self) -> None:
+        for key, value in DEFAULT_CONFIG.items():
+            if not hasattr(self, key):
+                logging.warning(
+                    f"Config is malformed, it does not have attribute '{key}'. Using default value."
+                )
+                setattr(self, key, value)
 
 
 def clear_cache():

--- a/src/visiomode/config.py
+++ b/src/visiomode/config.py
@@ -83,39 +83,29 @@ class Config(object):
 
             if os.path.exists(config_path):
                 logging.info(f"Loading config from {config_path}")
-                cls._load_config(config_path)
+                cls._instance._load_config(config_path)
             else:
                 logging.warning("No config file found, using defaults")
-                cls._set_defaults()
-                cls.save()
+                cls._instance._set_defaults()
+                cls._instance.save()
 
-            os.makedirs(cls.data_dir, exist_ok=True)
-            os.makedirs(cls.cache_dir, exist_ok=True)
-            os.makedirs(cls.db_dir, exist_ok=True)
+            os.makedirs(cls._instance.data_dir, exist_ok=True)
+            os.makedirs(cls._instance.cache_dir, exist_ok=True)
+            os.makedirs(cls._instance.db_dir, exist_ok=True)
 
         return cls._instance
 
-    @classmethod
-    def save(cls, path: typing.Optional[str] = None):
+    def save(self, path: typing.Optional[str] = None):
         if path is None:
-            path = cls.config_path
+            path = self.config_path
 
         with open(path, "w") as f:
-            json.dump(cls.to_dict(), f, indent=4)
+            json.dump(self.to_dict(), f, indent=4)
 
-    @classmethod
-    def to_dict(cls):
-        config = {}
-        for key in DEFAULT_CONFIG.keys():
-            try:
-                config[key] = getattr(cls, key)
-            except AttributeError:
-                logging.warning(f"Config is malformed, it does not have attribute '{key}'. Using default value.")
-                config[key] = DEFAULT_CONFIG[key]
-        return config
+    def to_dict(self):
+        return self.__dict__
 
-    @classmethod
-    def _load_config(cls, config_path: str):
+    def _load_config(self, config_path: str):
         """Loads config from a JSON file.
 
         Args:
@@ -126,15 +116,14 @@ class Config(object):
 
         for key, value in config.items():
             if key in DEFAULT_CONFIG:
-                setattr(cls, key, value)
+                setattr(self, key, value)
             else:
                 logging.warning("Unknown config key: {}".format(key))
 
-    @classmethod
-    def _set_defaults(cls):
+    def _set_defaults(self):
         """Sets config to default values."""
         for key, value in DEFAULT_CONFIG.items():
-            setattr(cls, key, value)
+            setattr(self, key, value)
 
 
 def clear_cache():

--- a/src/visiomode/config.py
+++ b/src/visiomode/config.py
@@ -2,17 +2,18 @@
 
 #  This file is part of visiomode.
 #  Copyright (c) 2020 Constantinos Eleftheriou <Constantinos.Eleftheriou@ed.ac.uk>
+#  Copyright (c) 2024 Olivier Delree <odelree@ed.ac.uk>
 #  Distributed under the terms of the MIT Licence.
 
 import os
 import shutil
 import json
 import logging
+import typing
 
 logging.basicConfig(level=logging.INFO)
 
-
-CONFIG_PATH = ".visiomode.json"
+DEFAULT_CONFIG_PATH = ".visiomode.json"
 
 DEFAULT_CONFIG = {
     "debug": True,
@@ -24,11 +25,11 @@ DEFAULT_CONFIG = {
     "width": 400,
     "height": 800,
     "fullscreen": False,
-    "devices": "devices/",
+    "devices": "devices",
 }
 
 
-class Config:
+class Config(object):
     """App configuration class.
 
     This class loads and saves configuration from a JSON file. If no config file exists, it creates one with default values.
@@ -38,92 +39,120 @@ class Config:
         flask_key: Flask secret key.
         data_dir: Path to data directory.
         cache_dir: Path to cache directory.
+        db_dir: Path to database directory.
         fps: Screen refresh rate in frames per second.
         width: Screen width.
         height: Screen height.
         fullscreen: Fullscreen mode flag.
         devices: Path to devices directory.
-        db_dir: Path to database directory.
     """
 
     debug: bool
     flask_key: str
     data_dir: str
     cache_dir: str
+    db_dir: str
     fps: int
     width: int
     height: int
     fullscreen: bool
     devices: str
-    db_dir: str = "visiomode_data/db"
 
-    def __init__(self, path=CONFIG_PATH):
-        """Initialises Config with a path to a configuration file.
+    _instance = None
 
-        If a valid configuration file exists, the program assumes it is NOT in debug mode, unless the config file specifies otherwise. If no config file exists, the program assumes it IS in debug mode.
+    def __new__(
+        cls,
+        config_path: typing.Optional[str] = None,
+    ) -> "Config":
+        """Initialise Config singleton with a path to a configuration file.
+
+        If a valid configuration file exists, the program assumes it is NOT in debug
+        mode, unless the config file specifies otherwise. If no config file exists, the
+        program assumes it IS in debug mode.
 
         Args:
-            path: Path to config JSON, defaults to DEFAULT_PATH. Only used if it exists.
+            config_path (str, optional): Path to config JSON, defaults to
+                                         DEFAULT_CONFIG_PATH. Only used if it exists.
         """
-        if os.path.exists(path):
-            logging.info(f"Loading config from {path}")
-            self._load_config(path)
-        else:
-            logging.warning("No config file found, using defaults")
-            self._set_defaults()
-            self.save()
+        if cls._instance is None:
+            cls._instance = super(Config, cls).__new__(cls)
 
-        os.makedirs(self.data_dir, exist_ok=True)
-        os.makedirs(self.cache_dir, exist_ok=True)
-        os.makedirs(self.db_dir, exist_ok=True)
+            if config_path is None:
+                config_path = DEFAULT_CONFIG_PATH
 
-    def save(self, path=CONFIG_PATH):
+            if os.path.exists(config_path):
+                logging.info(f"Loading config from {config_path}")
+                cls._load_config(config_path)
+            else:
+                logging.warning("No config file found, using defaults")
+                cls._set_defaults()
+                cls.save()
+
+            os.makedirs(cls.data_dir, exist_ok=True)
+            os.makedirs(cls.cache_dir, exist_ok=True)
+            os.makedirs(cls.db_dir, exist_ok=True)
+
+        return cls._instance
+
+    @classmethod
+    def save(cls, path: typing.Optional[str] = None):
+        if path is None:
+            path = DEFAULT_CONFIG_PATH
+
         with open(path, "w") as f:
-            json.dump(self.__dict__, f, indent=4)
+            json.dump(cls.to_dict(), f, indent=4)
 
-    def to_dict(self):
-        return self.__dict__
+    @classmethod
+    def to_dict(cls):
+        config = {}
+        for key in DEFAULT_CONFIG.keys():
+            try:
+                config[key] = getattr(cls, key)
+            except AttributeError:
+                logging.warning(f"Config is malformed, it does not have attribute '{key}'. Using default value.")
+                config[key] = DEFAULT_CONFIG[key]
+        return config
 
-    def _load_config(self, path):
+    @classmethod
+    def _load_config(cls, config_path: str):
         """Loads config from a JSON file.
 
         Args:
-            path: Path to config JSON file.
+            config_path: Path to config JSON file.
         """
-        with open(path, "r") as f:
+        with open(config_path, "r") as f:
             config = json.load(f)
 
         for key, value in config.items():
             if key in DEFAULT_CONFIG:
-                setattr(self, key, value)
+                setattr(cls, key, value)
             else:
                 logging.warning("Unknown config key: {}".format(key))
 
-    def _set_defaults(self):
+    @classmethod
+    def _set_defaults(cls):
         """Sets config to default values."""
         for key, value in DEFAULT_CONFIG.items():
-            setattr(self, key, value)
+            setattr(cls, key, value)
 
 
 def clear_cache():
     """Clears the cache directory."""
-    config = Config()
-    shutil.rmtree(config.cache_dir, ignore_errors=True)
-    os.makedirs(config.cache_dir, exist_ok=True)
+    shutil.rmtree(Config.cache_dir, ignore_errors=True)
+    os.makedirs(Config.cache_dir, exist_ok=True)
 
 
 def clear_db():
     """Clears the database directory."""
-    config = Config()
-    shutil.rmtree(config.db_dir, ignore_errors=True)
-    os.makedirs(config.db_dir, exist_ok=True)
+    shutil.rmtree(Config.db_dir, ignore_errors=True)
+    os.makedirs(Config.db_dir, exist_ok=True)
 
 
 def clear_data():
     """Clears the data directory."""
-    config = Config()
-    shutil.rmtree(config.data_dir, ignore_errors=True)
+    shutil.rmtree(Config.data_dir, ignore_errors=True)
 
     # Create new config file with default settings
+    Config._instance = None
     new_config = Config()
     new_config.save()

--- a/src/visiomode/config.py
+++ b/src/visiomode/config.py
@@ -28,7 +28,7 @@ DEFAULT_CONFIG = {
 }
 
 
-class Config(object):
+class Config:
     """App configuration class.
 
     This class loads and saves configuration from a JSON file. If no config file exists, it creates one with default values.

--- a/src/visiomode/config.py
+++ b/src/visiomode/config.py
@@ -144,19 +144,19 @@ class Config(object):
 
 def clear_cache():
     """Clears the cache directory."""
-    shutil.rmtree(Config.cache_dir, ignore_errors=True)
-    os.makedirs(Config.cache_dir, exist_ok=True)
+    shutil.rmtree(Config().cache_dir, ignore_errors=True)
+    os.makedirs(Config().cache_dir, exist_ok=True)
 
 
 def clear_db():
     """Clears the database directory."""
-    shutil.rmtree(Config.db_dir, ignore_errors=True)
-    os.makedirs(Config.db_dir, exist_ok=True)
+    shutil.rmtree(Config().db_dir, ignore_errors=True)
+    os.makedirs(Config().db_dir, exist_ok=True)
 
 
 def clear_data():
     """Clears the data directory."""
-    shutil.rmtree(Config.data_dir, ignore_errors=True)
+    shutil.rmtree(Config().data_dir, ignore_errors=True)
 
     # Create new config file with default settings
     Config._instance = None

--- a/src/visiomode/config.py
+++ b/src/visiomode/config.py
@@ -13,8 +13,6 @@ import typing
 
 logging.basicConfig(level=logging.INFO)
 
-DEFAULT_CONFIG_PATH = ".visiomode.json"
-
 DEFAULT_CONFIG = {
     "debug": True,
     "flask_key": "dev",
@@ -26,6 +24,7 @@ DEFAULT_CONFIG = {
     "height": 800,
     "fullscreen": False,
     "devices": "devices",
+    "config_path": ".visiomode.json",
 }
 
 
@@ -45,6 +44,7 @@ class Config(object):
         height: Screen height.
         fullscreen: Fullscreen mode flag.
         devices: Path to devices directory.
+        config_path: Path to the config.
     """
 
     debug: bool
@@ -57,6 +57,7 @@ class Config(object):
     height: int
     fullscreen: bool
     devices: str
+    config_path: str
 
     _instance = None
 
@@ -78,7 +79,7 @@ class Config(object):
             cls._instance = super(Config, cls).__new__(cls)
 
             if config_path is None:
-                config_path = DEFAULT_CONFIG_PATH
+                config_path = DEFAULT_CONFIG["config_path"]
 
             if os.path.exists(config_path):
                 logging.info(f"Loading config from {config_path}")
@@ -97,7 +98,7 @@ class Config(object):
     @classmethod
     def save(cls, path: typing.Optional[str] = None):
         if path is None:
-            path = DEFAULT_CONFIG_PATH
+            path = cls.config_path
 
         with open(path, "w") as f:
             json.dump(cls.to_dict(), f, indent=4)

--- a/src/visiomode/config.py
+++ b/src/visiomode/config.py
@@ -98,6 +98,8 @@ class Config(object):
     def save(self, path: typing.Optional[str] = None):
         if path is None:
             path = self.config_path
+        else:
+            self.config_path = path
 
         with open(path, "w") as f:
             json.dump(self.to_dict(), f, indent=4)

--- a/src/visiomode/config.py
+++ b/src/visiomode/config.py
@@ -92,6 +92,10 @@ class Config(object):
             os.makedirs(cls._instance.data_dir, exist_ok=True)
             os.makedirs(cls._instance.cache_dir, exist_ok=True)
             os.makedirs(cls._instance.db_dir, exist_ok=True)
+        elif config_path is not None:
+            logging.warning(
+                "Config has already been loaded, ignoring `config_path` passed to constructor."
+            )
 
         return cls._instance
 


### PR DESCRIPTION
Closes #197.

We used to have a `Config` class with a regular `__init__` constructor that would result in a new `Config` object being instantiated for each module that called it.
This PR restructures the class to be static and use the `__new__` constructor. The class now keeps track of a single instance that is created with the first `__new__` call and is returned with subsequent calls to the constructor. This has the advantage of synchronising the config across the whole application as only one config ever exists at the same time. Additionally, it means that the current syntax does not need to be modified throughout the application as `Config()` naturally makes use of `__new__` alone if no `__init__` exists.
This implementation assumes that only one config will ever be necessary for the application. However, if for some reason in the future (e.g., for simultaneous tests), we need multiple configs to exist at once, the class could be made to instead accept a config ID and keep track of a hashmap of configs.