### PR TITLE
Fix interface required elements

### DIFF
--- a/src/visiomode/webpanel/static/js/session.js
+++ b/src/visiomode/webpanel/static/js/session.js
@@ -277,38 +277,42 @@ loadAnimals();
 
 // Modals
 
+let addAnimalForm = document.getElementById("add-animal-form")
+
 let addAnimalButton = document.getElementById('add-animal-btn');
 
 function addAnimal() {
-    let animalId = document.getElementById("new-animal-id").value;
-    let animalDob = document.getElementById("new-animal-dob").value;
-    let animalSex = document.getElementById("new-animal-sex").value;
-    let animalSpecies = document.getElementById("new-animal-species").value;
-    let animalGenotype = document.getElementById("new-animal-genotype").value;
-    let animalDescription = document.getElementById("new-animal-description").value;
-    let animalRFID = document.getElementById("new-animal-rfid").value;
+    if (addAnimalForm.reportValidity()) {
+        let animalId = document.getElementById("new-animal-id").value;
+        let animalDob = document.getElementById("new-animal-dob").value;
+        let animalSex = document.getElementById("new-animal-sex").value;
+        let animalSpecies = document.getElementById("new-animal-species").value;
+        let animalGenotype = document.getElementById("new-animal-genotype").value;
+        let animalDescription = document.getElementById("new-animal-description").value;
+        let animalRFID = document.getElementById("new-animal-rfid").value;
 
-    return $.ajax({
-        type: 'POST',
-        url: "/api/animals",
-        data: JSON.stringify({
-            type: "add",
-            data: {
-                id: animalId,
-                dob: animalDob,
-                sex: animalSex,
-                species: animalSpecies,
-                genotype: animalGenotype,
-                description: animalDescription,
-                rfid: animalRFID,
-            },
-        }),
-        dataType: "json",
-        contentType: "application/json",
-        success: function () {
-            $("#addAnimal").modal("hide");
-        }
-    });
+        return $.ajax({
+            type: 'POST',
+            url: "/api/animals",
+            data: JSON.stringify({
+                type: "add",
+                data: {
+                    id: animalId,
+                    dob: animalDob,
+                    sex: animalSex,
+                    species: animalSpecies,
+                    genotype: animalGenotype,
+                    description: animalDescription,
+                    rfid: animalRFID,
+                },
+            }),
+            dataType: "json",
+            contentType: "application/json",
+            success: function () {
+                $("#addAnimal").modal("hide");
+            }
+        });
+    }
 }
 
 addAnimalButton.onclick = function () {

--- a/src/visiomode/webpanel/templates/index.html
+++ b/src/visiomode/webpanel/templates/index.html
@@ -171,7 +171,7 @@
                 </button>
             </div>
             <div class="modal-body">
-                <form>
+                <form id="add-animal-form">
                     <div class="form-group row">
                         <label for="new-animal-id" class="col-sm-3 col-form-label">Animal ID<sup>*</sup></label>
                         <div class="col-sm-5">
@@ -188,7 +188,7 @@
                         <label for="new-animal-sex" class="col-sm-3 col-form-label">Sex<sup>*</sup></label>
                         <div class="col-sm-5">
                             <div class="form-check">
-                                <select id="new-animal-sex" class="custom-select form-control">
+                                <select id="new-animal-sex" class="custom-select form-control" required>
                                     <option value="U">Unknown</option>
                                     <option value="M">Male</option>
                                     <option value="F">Female</option>

--- a/src/visiomode/webpanel/templates/index.html
+++ b/src/visiomode/webpanel/templates/index.html
@@ -20,7 +20,7 @@
 
                                             <label for="animal_id">Animal ID</label>
                                             <div class="input-group">
-                                                <select id="animal_id" class="custom-select form-control mb-3"></select>
+                                                <select id="animal_id" class="custom-select form-control mb-3" required></select>
                                                 <div class="input-group-append mb-3">
                                                 <a class="btn btn-outline-secondary" role="button" href="#" data-toggle="modal"
                                                 data-target="#addAnimal">Add animal</a>


### PR DESCRIPTION
Closes #201.

The behaviour should now be that both an animal entry and an experiment ID are required to start a session.
Additionally, the `addAnimal` modal dialogue should now properly force required fields to be filled before allowing the user to add a new animal to the database.

Please note that I have essentially no experience in Javascript so don't hesitate to let me know if something is not quite right.