### PR TITLE
Delay import of `pynwb`

### DIFF
--- a/src/visiomode/webpanel/export.py
+++ b/src/visiomode/webpanel/export.py
@@ -8,9 +8,10 @@ converted file stored in Visiomode's cache directory.
 #  This file is part of visiomode.
 #  Copyright (c) 2023 Constantinos Eleftheriou <Constantinos.Eleftheriou@ed.ac.uk>
 #  Distributed under the terms of the MIT Licence.
+
+# Note that `pynwb` is imported inside its own function to save on startup time
 import os
 import json
-import pynwb
 import pandas as pd
 
 import visiomode.config as cfg
@@ -22,6 +23,9 @@ config = cfg.Config()
 
 
 def to_nwb(session_path):
+    # Delayed import to save on startup time
+    import pynwb
+
     with open(session_path, "r") as f:
         session = json.load(f)
 

--- a/src/visiomode/webpanel/export.py
+++ b/src/visiomode/webpanel/export.py
@@ -7,6 +7,7 @@ converted file stored in Visiomode's cache directory.
 """
 #  This file is part of visiomode.
 #  Copyright (c) 2023 Constantinos Eleftheriou <Constantinos.Eleftheriou@ed.ac.uk>
+#  Copyright (c) 2024 Olivier Delree <odelree@ed.ac.uk>
 #  Distributed under the terms of the MIT Licence.
 
 # Note that `pynwb` is imported inside its own function to save on startup time


### PR DESCRIPTION
Closes #205.

As mentioned in the issue, the import time of `visiomode` (and its startup time) can be cut in 4 if the `pywnb` import is delayed until the `to_nwb()` function is called for the first time.
Although it's not too elegant to have imports declared after the top of the file, the function is visible from the top and comments explain the reasoning behind the structure.