### PR TITLE
Allow customisation of the `instance` directory location

### DIFF
--- a/src/visiomode/config.py
+++ b/src/visiomode/config.py
@@ -18,6 +18,7 @@ DEFAULT_CONFIG = {
     "debug": True,
     "flask_key": "dev",
     "data_dir": "visiomode_data",
+    "instance_dir": "visiomode_data/instance",
     "cache_dir": "visiomode_data/cache",
     "db_dir": "visiomode_data/db",
     "fps": 60,
@@ -37,6 +38,7 @@ class Config:
         debug: Debug mode flag.
         flask_key: Flask secret key.
         data_dir: Path to data directory.
+        instance_dir: Path to the Flask instance directory.
         cache_dir: Path to cache directory.
         fps: Screen refresh rate in frames per second.
         width: Screen width.
@@ -49,6 +51,7 @@ class Config:
     debug: bool
     flask_key: str
     data_dir: str
+    instance_dir: str
     cache_dir: str
     fps: int
     width: int

--- a/src/visiomode/webpanel/__init__.py
+++ b/src/visiomode/webpanel/__init__.py
@@ -23,7 +23,7 @@ def create_app(action_q=None, log_q=None):
     """
     config = cfg.Config()
 
-    app = flask.Flask(__name__)
+    app = flask.Flask(__name__, instance_path=os.path.abspath(config.instance_dir))
     app.config.from_mapping({"SECRET_KEY": config.flask_key, "DEBUG": config.debug})
 
     # ensure that instance dir exists


### PR DESCRIPTION
Closes #207.

The directory was the only path left that wasn't left to the config user to decide.
This PR fixes that.