### PR TITLE
Update recommended Python version to 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 name = "visiomode"
 description = "An open-source platform for touchscreen-based visuomotor tasks in rodents."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { file = "LICENSE" }
 authors = [
   { name = "Constantinos Eleftheriou", email = "Constantinos.Eleftheriou@ed.ac.uk" },

--- a/src/visiomode/core.py
+++ b/src/visiomode/core.py
@@ -2,15 +2,16 @@
 
 #  This file is part of visiomode.
 #  Copyright (c) 2020 Constantinos Eleftheriou <Constantinos.Eleftheriou@ed.ac.uk>
+#  Copyright (c) 2024 Olivier Delree <odelree@ed.ac.uk>
 #  Distributed under the terms of the MIT Licence.
 
+import importlib.resources as resources
 import os
 import logging
 import time
 import datetime
 import threading
 import queue
-import pkg_resources
 import pygame as pg
 import visiomode.config as conf
 import visiomode.models as models
@@ -56,7 +57,7 @@ class Visiomode:
         # Set app icon
         # Dimensions should be 512x512, 300 ppi for retina
         icon = pg.image.load(
-            pkg_resources.resource_filename("visiomode.res", "icon.png")
+            str(resources.files("visiomode.res") / "icon.png")
         )
         pg.display.set_icon(icon)
 
@@ -89,7 +90,7 @@ class Visiomode:
 
         # Loading screen - wait until webpanel comes online
         loading_img = pg.image.load(
-            pkg_resources.resource_filename("visiomode.res", "loading.png")
+            str(resources.files("visiomode.res") / "loading.png"),
         )
         loading_img = pg.transform.smoothscale(loading_img, (100, 100))
         loading_img_pos = loading_img.get_rect()


### PR DESCRIPTION
This is the first step in upgrading to 3.12 and closes #210.

Apart from bumping the `pyproject.toml` to required 3.9 and above, this PR also replaces the use of `pkg_resources` in favour of `importlib.resources` as the former is deprecated as of 3.12. I figured since the behaviour is equivalent, it was best to make the change as early as possible to make life easier bumping to other versions.

I've not encoutered any trouble working with 3.9 locally but I am not working on a Raspberry Pi so I'll wait until it's been tested on one before opening another PR updating to another version.