### PR TITLE
Add test(s?) for app launch

### DIFF
--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -1,18 +1,34 @@
 #  This file is part of visiomode.
 #  Copyright (c) 2022 Constantinos Eleftheriou <Constantinos.Eleftheriou@ed.ac.uk>
+#  Copyright (c) 2024 Olivier Delree <odelree@ed.ac.uk>
 #  Distributed under the terms of the MIT Licence.
 
-#  This file is part of visiomode.
-#  Copyright (c) 2022 Constantinos Eleftheriou <Constantinos.Eleftheriou@ed.ac.uk>
-#  Distributed under the terms of the MIT Licence.
-
+import pygame
 import unittest
-import visiomode
+
+import visiomode.core as core
 
 
 class AppLaunch(unittest.TestCase):
-    def test_launch(self):
-        pass
+    @classmethod
+    def setUpClass(cls) -> None:
+        # Ensure pygame is initialised
+        pygame.init()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        # Ensure to clean up pygame
+        pygame.quit()
+
+    @staticmethod
+    def test_launch() -> None:
+        """Test the application starts as expected."""
+        # Set up a timer to automatically close the application as soon as it enters
+        # its main loop.
+        pygame.time.set_timer(pygame.event.Event(pygame.QUIT), 100)
+
+        # Start the application
+        core.Visiomode()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #72.

This PR implements the placeholder test for app launch. It justs starts the app and quits it as soon as the main loop is started.
I can't really think of any other tests that would be related to app startup but I'm happy to get suggestions.

If we want to have tests regarding the webpanel starting, it'd be nice to either have a separation between regular app startup and webpanel startup or a means of shutting down the webpanel (e.g., `/shutdown` route) so that each test gets its own webpanel instance.