### PR TITLE
Add experimenter profile to interface and session metadata

### DIFF
--- a/src/visiomode/core.py
+++ b/src/visiomode/core.py
@@ -188,6 +188,7 @@ class Visiomode:
                 protocol = protocols.get_protocol(request["data"].pop("protocol"))
                 self.session = models.Session(
                     animal_id=request["data"].pop("animal_id"),
+                    experimenter_name=request["data"].pop("experimenter_name"),
                     experiment=request["data"].pop("experiment"),
                     duration=float(request["data"].pop("duration")),
                     timestamp=datetime.datetime.now().isoformat(),

--- a/src/visiomode/models.py
+++ b/src/visiomode/models.py
@@ -98,6 +98,7 @@ class Session(Base):
 
     Attributes:
         animal_id: String representing the animal identifier.
+        experimenter_name: String representing the experimenter's name.
         experiment: A string holding the experiment identifier.
         protocol: An instance of the Protocol class.
         duration: Integer representing the session duration in minutes.
@@ -107,10 +108,12 @@ class Session(Base):
         device: String hostname of the device running the session. Defaults to the hostname provided by the socket lib.
         trials: A mutable list of session trials; each trial is an instance of the Trial dataclass. Automatically populated using protocol.trials after class instantiation.
         animal_meta: A dictionary with animal metadata (see Animal class). Automatically populated using animal_id after class instantiation.
+        experimenter_meta: A dictionary with experimenter metadata (see Experimenter class). Automatically populated using experimenter_name after class instantiation.
         version: Visiomode version this was generated with.
     """
 
     animal_id: str
+    experimenter_name: str
     experiment: str
     duration: float
     protocol: None = None
@@ -121,10 +124,12 @@ class Session(Base):
     device: str = socket.gethostname()
     trials: typing.List[Trial] = dataclasses.field(default_factory=list)
     animal_meta: dict = None
+    experimenter_meta: dict = None
     version: str = __about__.__version__
 
     def __post_init__(self):
         self.animal_meta = Animal.get_animal(self.animal_id)
+        self.experimenter_meta = Experimenter.get_experimenter(self.experimenter_name)
         self.trials = self.protocol.trials
 
     def to_dict(self):

--- a/src/visiomode/webpanel/__init__.py
+++ b/src/visiomode/webpanel/__init__.py
@@ -62,6 +62,11 @@ def create_app(action_q=None, log_q=None):
         """Animals view/edit page."""
         return flask.render_template("settings-animals.html")
 
+    @app.route("/settings-experimenters")
+    def settings_experimenters():
+        """Experimenters view/edit page."""
+        return flask.render_template("settings-experimenters.html")
+
     @app.route("/help")
     def docs():
         """Help / documentation page."""

--- a/src/visiomode/webpanel/__init__.py
+++ b/src/visiomode/webpanel/__init__.py
@@ -2,6 +2,7 @@
 
 #  This file is part of visiomode.
 #  Copyright (c) 2020 Constantinos Eleftheriou <Constantinos.Eleftheriou@ed.ac.uk>
+#  Copyright (c) 2024 Olivier Delree <odelree@ed.ac.uk>
 #  Distributed under the terms of the MIT Licence.
 
 import os
@@ -123,6 +124,12 @@ def create_app(action_q=None, log_q=None):
     app.add_url_rule(
         "/api/animals",
         view_func=api.AnimalsAPI.as_view("animals_api"),
+        methods=["GET", "POST"],
+    )
+
+    app.add_url_rule(
+        "/api/experimenters",
+        view_func=api.ExperimentersAPI.as_view("experimenters_api"),
         methods=["GET", "POST"],
     )
 

--- a/src/visiomode/webpanel/export.py
+++ b/src/visiomode/webpanel/export.py
@@ -32,12 +32,28 @@ def to_nwb(session_path):
 
     session_start_time = datetime.fromisoformat(session["timestamp"])
 
-    nwbfile = pynwb.NWBFile(
-        session_description="Visiomode {} behaviour".format(session.get("protocol")),
-        identifier=session_path.split("/")[-1].replace(".json", ""),
-        session_start_time=session_start_time,
-        experiment_description=session.get("experiment"),
-    )
+    experimenter_metadata = session["experimenter_meta"]
+    if experimenter_metadata:
+        nwbfile = pynwb.NWBFile(
+            session_description="Visiomode {} behaviour".format(
+                session.get("protocol")
+            ),
+            identifier=session_path.split("/")[-1].replace(".json", ""),
+            session_start_time=session_start_time,
+            experiment_description=session.get("experiment"),
+            experimenter=experimenter_metadata.get("experimenter_name"),
+            lab=experimenter_metadata.get("laboratory_name"),
+            institution=experimenter_metadata.get("institution_name"),
+        )
+    else:
+        nwbfile = pynwb.NWBFile(
+            session_description="Visiomode {} behaviour".format(
+                session.get("protocol")
+            ),
+            identifier=session_path.split("/")[-1].replace(".json", ""),
+            session_start_time=session_start_time,
+            experiment_description=session.get("experiment"),
+        )
 
     nwbfile.subject = pynwb.file.Subject(subject_id=session["animal_id"])
 

--- a/src/visiomode/webpanel/static/js/session.js
+++ b/src/visiomode/webpanel/static/js/session.js
@@ -1,6 +1,7 @@
 /*
  * This file is part of visiomode.
  * Copyright (c) 2020 Constantinos Eleftheriou <Constantinos.Eleftheriou@ed.ac.uk>
+ * Copyright (c) 2024 Olivier Delree <odelree@ed.ac.uk>
  * Distributed under the terms of the MIT Licence.
  */
 let form = document.getElementById('session-form');
@@ -274,6 +275,23 @@ function loadAnimals() {
 
 loadAnimals();
 
+// load experimenters
+function loadExperimenters() {
+    let experimenter_selector = document.getElementById('experimenter_name');
+    return $.get("/api/experimenters").done(function (data) {
+        experimenter_selector.innerHTML = "";
+        data.experimenters.reverse(); // reverse order to show latest experimenters first
+        data.experimenters.forEach(function (experimenter) {
+            let option = document.createElement('option');
+            option.value = experimenter.experimenter_name;
+            option.text = experimenter.experimenter_name;
+            experimenter_selector.add(option);
+        });
+    });
+}
+
+loadExperimenters();
+
 
 // Modals
 
@@ -317,4 +335,38 @@ function addAnimal() {
 
 addAnimalButton.onclick = function () {
     addAnimal().done(loadAnimals);
+}
+
+let addExperimenterForm = document.getElementById("add-experimenter-form")
+
+let addExperimenterButton = document.getElementById('add-experimenter-btn');
+
+function addExperimenter() {
+    if (addExperimenterForm.reportValidity()) {
+        let experimenterName = document.getElementById("new-experimenter-name").value;
+        let laboratoryName = document.getElementById("new-laboratory-name").value;
+        let institutionName = document.getElementById("new-institution-name").value;
+
+        return $.ajax({
+            type: 'POST',
+            url: "/api/experimenters",
+            data: JSON.stringify({
+                type: "add",
+                data: {
+                    experimenter_name: experimenterName,
+                    laboratory_name: laboratoryName,
+                    institution_name: institutionName,
+                },
+            }),
+            dataType: "json",
+            contentType: "application/json",
+            success: function () {
+                $("#addExperimenter").modal("hide");
+            }
+        });
+    }
+}
+
+addExperimenterButton.onclick = function () {
+    addExperimenter().done(loadExperimenters);
 }

--- a/src/visiomode/webpanel/static/js/settings-experimenters.js
+++ b/src/visiomode/webpanel/static/js/settings-experimenters.js
@@ -1,0 +1,109 @@
+/*
+ * This file is part of visiomode.
+ * Copyright (c) 2023 Constantinos Eleftheriou <Constantinos.Eleftheriou@ed.ac.uk>
+ * Copyright (c) 2024 Olivier Delree <odelree@ed.ac.uk>
+ * Distributed under the terms of the MIT Licence.
+ */
+
+let table = document.getElementById("experimentersTableData");
+let updateExperimenterButton = document.getElementById('update-experimenter-btn');
+let deleteExperimenterButton = document.getElementById('delete-experimenter-btn');
+let experimenters = [];
+
+
+function loadExperimenters() {
+    fetch("/api/experimenters")
+        .then((response) => {
+            return response.json();
+        })
+        .then((data) => {
+            experimenters = data.experimenters;
+            experimenters.sort(function (a, b) {
+                if (a.experimenter_name < b.experimenter_name) {
+                    return -1;
+                } else if (a.experimenter_name > b.experimenter_name) {
+                    return 1;
+                }
+                return 0;
+            });
+
+            let experimentersTableData = document.getElementById("experimentersTableData");
+            experimentersTableData.innerHTML = "";
+            experimenters.forEach(experimenter => {
+                let row = experimentersTableData.insertRow();
+                let experimenter_name = row.insertCell(0);
+                experimenter_name.innerHTML = experimenter.experimenter_name;
+                let laboratory_name = row.insertCell(1);
+                laboratory_name.innerHTML = experimenter.laboratory_name;
+                let institution_name = row.insertCell(2);
+                institution_name.innerHTML = experimenter.institution_name;
+            });
+        });
+}
+
+table.onclick = function (event) {
+    let experimenter_name = event.target.parentNode.cells[0].innerHTML;
+    let selected_experimenter = experimenters.find(element => element.experimenter_name === experimenter_name);
+    console.log(selected_experimenter);
+    $("#updateExperimenter").modal();
+    document.getElementById("experimenter-name").value = selected_experimenter.experimenter_name;
+    document.getElementById("previous-experimenter-name").value = selected_experimenter.experimenter_name;
+    document.getElementById("laboratory-name").value = selected_experimenter.laboratory_name;
+    document.getElementById("institution-name").value = selected_experimenter.institution_name;
+}
+
+function updateExperimenter() {
+    let experimenterName = document.getElementById("experimenter-name").value;
+    let previousExperimenterName = document.getElementById("previous-experimenter-name").value;
+    let laboratoryName = document.getElementById("laboratory-name").value;
+    let institutionName = document.getElementById("institution-name").value;
+
+    $.ajax({
+        type: 'POST',
+        url: "/api/experimenters",
+        data: JSON.stringify({
+            type: "update",
+            data: {
+                experimenter_name: experimenterName,
+                previous_experimenter_name: previousExperimenterName,
+                laboratory_name: laboratoryName,
+                institution_name: institutionName,
+            },
+        }),
+        dataType: "json",
+        contentType: "application/json",
+        success: function (data) {
+            console.log(data);
+            loadExperimenters();
+            $("#updateExperimenter").modal("toggle")
+        }
+    });
+}
+
+updateExperimenterButton.onclick = function () {
+    updateExperimenter();
+}
+
+
+deleteExperimenterButton.onclick = function () {
+    let experimenterName = document.getElementById("experimenter-name").value;
+    $.ajax({
+        type: 'POST',
+        url: "/api/experimenters",
+        data: JSON.stringify({
+            type: "delete",
+            data: {
+                experimenter_name: experimenterName,
+            },
+        }),
+        dataType: "json",
+        contentType: "application/json",
+        success: function (data) {
+            console.log(data);
+            loadExperimenters();
+            $("#updateExperimenter").modal("toggle")
+        }
+    });
+}
+
+loadExperimenters();

--- a/src/visiomode/webpanel/static/js/settings.js
+++ b/src/visiomode/webpanel/static/js/settings.js
@@ -1,6 +1,7 @@
 /*
  * This file is part of visiomode.
  * Copyright (c) 2023 Constantinos Eleftheriou <Constantinos.Eleftheriou@ed.ac.uk>
+ * Copyright (c) 2024 Olivier Delree <odelree@ed.ac.uk>
  * Distributed under the terms of the MIT Licence.
  */
 
@@ -13,6 +14,9 @@ let deleteAllDataButton = document.getElementById('delete-all-data-btn');
 
 let addAnimalButton = document.getElementById('add-animal-btn');
 let deleteAnimalDataButton = document.getElementById('delete-animal-data-btn');
+
+let addExperimenterButton = document.getElementById('add-experimenter-btn');
+let deleteExperimenterDataButton = document.getElementById('delete-experimenter-data-btn');
 
 
 /// Display & storage settings
@@ -104,6 +108,77 @@ deleteAllDataButton.onclick = function () {
 
 
 loadSettings();
+
+
+// Experimenters
+
+function addExperimenter() {
+    let experimenterName = document.getElementById("new-experimenter-name").value;
+    let laboratoryName = document.getElementById("new-laboratory-name").value;
+    let institutionName = document.getElementById("new-institution-name").value;
+
+    $.ajax({
+        type: 'POST',
+        url: "/api/experimenters",
+        data: JSON.stringify({
+            type: "add",
+            data: {
+                experimenter_name: experimenterName,
+                laboratory_name: laboratoryName,
+                institution_name: institutionName,
+            },
+        }),
+        dataType: "json",
+        contentType: "application/json",
+        success: function (data) {
+            $("#addExperimenter").modal("hide");
+        }
+    });
+}
+
+addExperimenterButton.onclick = function () {
+    addExperimenter();
+}
+
+function exportExperimenters() {
+    // Export animals as CSV
+    $.get("/api/experimenters", function (data) {
+        experimenters = data.experimenters;
+        let replacer = (key, value) => value === null ? '' : value
+        let header = Object.keys(experimenters[0])
+        let csv = [
+            header.join(','), // header row first
+            ...experimenters.map(row => header.map(
+                fieldName => JSON.stringify(row[fieldName], replacer)).join(','))
+        ].join('\r\n');
+        let csvExport = new Blob([csv], {type: "text/csv"});
+        let url = window.URL.createObjectURL(csvExport);
+        let a = document.createElement('a');
+        a.href = url;
+        a.download = 'experimenters.csv';
+        a.click();
+    });
+}
+
+function deleteExperimenterData() {
+    $.ajax({
+        type: 'POST',
+        url: "/api/experimenters",
+        data: JSON.stringify({
+            type: "delete",
+            data: {},
+        }),
+        dataType: "json",
+        contentType: "application/json",
+        success: function (data) {
+            $("#deleteExperimenterData").modal("hide");
+        }
+    });
+}
+
+deleteExperimenterDataButton.onclick = function () {
+    deleteExperimenterData();
+}
 
 
 /// Animals

--- a/src/visiomode/webpanel/templates/index.html
+++ b/src/visiomode/webpanel/templates/index.html
@@ -15,18 +15,31 @@
                             <form id="session-form">
                                 <div class="row">
                                     <div class="col">
-                                        <div class="form-group">
-                                            <!-- Animal Selector -->
-
-                                            <label for="animal_id">Animal ID</label>
-                                            <div class="input-group">
-                                                <select id="animal_id" class="custom-select form-control mb-3" required></select>
-                                                <div class="input-group-append mb-3">
-                                                <a class="btn btn-outline-secondary" role="button" href="#" data-toggle="modal"
-                                                data-target="#addAnimal">Add animal</a>
-                                                </div>
+                                        <!-- Animal Selector -->
+                                        <label for="animal_id">Animal ID</label>
+                                        <div class="input-group">
+                                            <select id="animal_id" class="custom-select form-control mb-3" required></select>
+                                            <div class="input-group-append mb-3">
+                                            <a class="btn btn-outline-secondary" role="button" href="#" data-toggle="modal" data-target="#addAnimal">Add animal</a>
                                             </div>
-                                            <!-- Protocol selector -->
+                                        </div>
+                                        <label for="experiment">Experiment Reference</label>
+                                        <input id="experiment" class="form-control mb-3" type="text" placeholder="experiment id" required>
+                                    </div>
+                                    <div class="col">
+                                        <!-- Experimenter Selector -->
+                                        <label for="experimenter_name">Experimenter</label>
+                                        <div class="input-group">
+                                            <select id="experimenter_name" class="custom-select form-control mb-3"></select>
+                                            <div class="input-group-append mb-3">
+                                            <a class="btn btn-outline-secondary" role="button" href="#" data-toggle="modal" data-target="#addExperimenter">Add experimenter</a>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col">
+                                        <!-- Protocol selector -->
                                             <label for="protocol">Protocol</label>
                                             <select id="protocol" class="custom-select form-control mb-3">
                                                 <optgroup label="Tasks">
@@ -40,15 +53,8 @@
                                                     {% endfor %}
                                                 </optgroup>
                                             </select>
-                                        </div>
                                     </div>
                                     <div class="col">
-                                        <label for="experiment">Experiment Reference</label>
-                                        <input id="experiment"
-                                               class="form-control mb-3"
-                                               type="text"
-                                               placeholder="experiment id"
-                                               required>
                                         <label for="duration">Duration (mins)</label>
                                         <input id="duration" class="form-control mb-3"
                                                type="number" value="30"
@@ -228,6 +234,48 @@
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                 <button type="button" class="btn btn-primary" id="add-animal-btn">Save animal</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="addExperimenter" tabindex="-1" role="dialog"
+    aria-labelledby="addExperimenterTitle" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="addExperimenterLongTitle">Add experimenter</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <form id="add-experimenter-form">
+                    <div class="form-group row align-items-center">
+                        <label for="new-experimenter-name" class="col-sm-5 col-form-label">Experimenter name<sup>*</sup><br>(first and last name)</label>
+                        <div class="col-sm-7">
+                            <input type="text" class="form-control" id="new-experimenter-name" required>
+                        </div>
+                    </div>
+                    <div class="form-group row">
+                        <label for="new-laboratory-name" class="col-sm-5 col-form-label">Laboratory name<sup>*</sup></label>
+                        <div class="col-sm-7">
+                            <input type="text" class="form-control" id="new-laboratory-name" required>
+                        </div>
+                    </div>
+                    <div class="form-group row">
+                        <label for="new-institution-name" class="col-sm-5 col-form-label">Institution name<sup>*</sup></label>
+                        <div class="col-sm-7">
+                            <input type="text" class="form-control" id="new-institution-name" required>
+                        </div>
+                    </div>
+                </form>
+
+                <sup>*</sup> Indicates a required field.
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary" id="add-experimenter-btn">Save experimenter</button>
             </div>
         </div>
     </div>

--- a/src/visiomode/webpanel/templates/settings-experimenters.html
+++ b/src/visiomode/webpanel/templates/settings-experimenters.html
@@ -1,0 +1,78 @@
+{% extends "base.html" %}
+{% set active_page = "settings" %}
+{% block title %}Settings{% endblock %}
+
+{% block content %}
+<div class="card shadow">
+    <div class="card-header py-3">
+        <p class="text-primary m-0 font-weight-bold">Experimenters</p>
+    </div>
+    <div class="card-body">
+        <div class="table-responsive">
+            <table  class="table table-hover" id="animalsTable">
+                <thead>
+                    <tr>
+                        <th>Experimenter name</th>
+                        <th>Laboratory name</th>
+                        <th>Institution name</th>
+                    </tr>
+                </thead>
+                <tbody id="experimentersTableData"></tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="updateExperimenter" tabindex="-1" role="dialog"
+    aria-labelledby="updateExperimenterTitle" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="updateExperimenterLongTitle">Edit experimenter details</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <form id="add-experimenter-form">
+                    <div class="form-group row align-items-center">
+                        <label for="experimenter-name" class="col-sm-5 col-form-label">Experimenter name<sup>*</sup><br>(first and last name)</label>
+                        <div class="col-sm-7">
+                            <input type="text" class="form-control" id="experimenter-name" required>
+                        </div>
+                    </div>
+                    <div class="form-group row d-none">
+                        <label for="previous-experimenter-name" class="col-sm-5 col-form-label">Experimenter name<sup>*</sup><br>(first and last name)</label>
+                        <div class="col-sm-7">
+                            <input type="text" class="form-control" id="previous-experimenter-name" required>
+                        </div>
+                    </div>
+                    <div class="form-group row">
+                        <label for="laboratory-name" class="col-sm-5 col-form-label">Laboratory name<sup>*</sup></label>
+                        <div class="col-sm-7">
+                            <input type="text" class="form-control" id="laboratory-name" required>
+                        </div>
+                    </div>
+                    <div class="form-group row">
+                        <label for="institution-name" class="col-sm-5 col-form-label">Institution name<sup>*</sup></label>
+                        <div class="col-sm-7">
+                            <input type="text" class="form-control" id="institution-name" required>
+                        </div>
+                    </div>
+                </form>
+
+                <sup>*</sup> Indicates a required field.
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary" id="delete-experimenter-btn">Delete</button>
+                <button type="button" class="btn btn-primary" id="update-experimenter-btn">Save changes</button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script type="text/javascript" src="static/js/settings-experimenters.js"></script>
+{% endblock %}

--- a/src/visiomode/webpanel/templates/settings.html
+++ b/src/visiomode/webpanel/templates/settings.html
@@ -34,11 +34,11 @@
                     </div>
                     <div class="card-body" style="min-height: 178px;">
                         <ul style="list-style-type: none" class="list-group list-group-flush">
-                            <li class="list-group-item"><a href="#">Add new experimenter</a></li>
-                            <li class="list-group-item"><a href="#">View/edit experimenter details</a></li>
-                            <li class="list-group-item"><a href="#">Export experimenter metadata</a></li>
-                            <li class="list-group-item"><a href="#" class="text-danger">Delete all experimenter
-                                    data</a></li>
+                            <li class="list-group-item"><a href="#" data-toggle="modal"
+                                data-target="#addExperimenter">Add new experimenter</a></li>
+                            <li class="list-group-item"><a href="/settings-experimenters">View/edit experimenter details</a></li>
+                            <li class="list-group-item"><a onclick="exportExperimenters()" href="#">Export experimenter metadata</a></li>
+                            <li class="list-group-item" data-toggle="modal" data-target="#deleteExperimenterData"><a href="#" class="text-danger">Delete all experimenter data</a></li>
                         </ul>
                     </div>
                 </div>
@@ -256,6 +256,71 @@
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                 <button type="button" class="btn btn-primary" id="display-settings-btn">Save changes</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="addExperimenter" tabindex="-1" role="dialog"
+    aria-labelledby="addExperimenterTitle" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="addExperimenterLongTitle">Add experimenter</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <form id="add-experimenter-form">
+                    <div class="form-group row align-items-center">
+                        <label for="new-experimenter-name" class="col-sm-5 col-form-label">Experimenter name<sup>*</sup><br>(first and last name)</label>
+                        <div class="col-sm-7">
+                            <input type="text" class="form-control" id="new-experimenter-name" required>
+                        </div>
+                    </div>
+                    <div class="form-group row">
+                        <label for="new-laboratory-name" class="col-sm-5 col-form-label">Laboratory name<sup>*</sup></label>
+                        <div class="col-sm-7">
+                            <input type="text" class="form-control" id="new-laboratory-name" required>
+                        </div>
+                    </div>
+                    <div class="form-group row">
+                        <label for="new-institution-name" class="col-sm-5 col-form-label">Institution name<sup>*</sup></label>
+                        <div class="col-sm-7">
+                            <input type="text" class="form-control" id="new-institution-name" required>
+                        </div>
+                    </div>
+                </form>
+
+                <sup>*</sup> Indicates a required field.
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-primary" id="add-experimenter-btn">Save experimenter</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="modal fade" id="deleteExperimenterData" tabindex="-1" role="dialog" aria-labelledby="deleteExperimenterDataTitle"
+    aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="deleteExperimenterDataLongTitle">Delete animal profile data</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <p>Deleting experimenter profile data will remove all metadata Visiomode holds on experimenters.</p>
+                <p>Session data will not be affected.</p>
+                <p class="text-danger">Warning: this action cannot be undone.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                <button type="button" class="btn btn-danger" id="delete-experimenter-data-btn">Delete experimenter profile data</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Closes #178.

This PR adds functionality for an experimenter select element essentially exactly the same as the one for animal metadata.
It is accompanied by a modal to enter information about the experimenter (name, lab name, institution name). Profiles are kept ina a database similar to the one used for animals.
If a profile has been selected when a session is started, its metadata is included with the session so that it can be retrieved later on. The only use currently is to package the metadata with an output NWB file if the user requests it. If the session was started without an experimenter profile, the NWB file is still created but without the extra information.