### PR TITLE
Apply black on current codebase

### DIFF
--- a/src/visiomode/mixins.py
+++ b/src/visiomode/mixins.py
@@ -1,4 +1,5 @@
 """Useful Mixins for class code reuse."""
+
 #  This file is part of visiomode.
 #  Copyright (c) 2020 Constantinos Eleftheriou <Constantinos.Eleftheriou@ed.ac.uk>
 #  Distributed under the terms of the MIT Licence.

--- a/src/visiomode/protocols/__init__.py
+++ b/src/visiomode/protocols/__init__.py
@@ -76,7 +76,7 @@ class Task(Protocol):
         response_address,
         reward_address,
         reward_profile,
-        **kwargs
+        **kwargs,
     ):
         super().__init__(screen)
 

--- a/src/visiomode/webpanel/export.py
+++ b/src/visiomode/webpanel/export.py
@@ -5,6 +5,7 @@ Each export function takes a `session_path` argument, a string pointing to the
 location of a stored session JSON file, and returns a string reference to the
 converted file stored in Visiomode's cache directory.
 """
+
 #  This file is part of visiomode.
 #  Copyright (c) 2023 Constantinos Eleftheriou <Constantinos.Eleftheriou@ed.ac.uk>
 #  Copyright (c) 2024 Olivier Delree <odelree@ed.ac.uk>

--- a/tests/test_stimuli.py
+++ b/tests/test_stimuli.py
@@ -174,7 +174,7 @@ class StimuliFunctionsTest(unittest.TestCase):
         normalised_array = stimuli.normalise_array(float_array)
 
         self.assertGreaterEqual(normalised_array.min(), 0)
-        self.assertLess(normalised_array.max(), 2 ** 8)
+        self.assertLess(normalised_array.max(), 2**8)
         self.assertEqual(normalised_array.dtype, np.uint8)
 
     def test_grayscale_array(self) -> None:
@@ -184,7 +184,7 @@ class StimuliFunctionsTest(unittest.TestCase):
 
         self.assertEqual(grayscale_array.shape, (8, 7, 3))
         self.assertGreaterEqual(grayscale_array.min(), 0)
-        self.assertLess(grayscale_array.max(), 2 ** 8)
+        self.assertLess(grayscale_array.max(), 2**8)
         self.assertEqual(grayscale_array.dtype, np.uint8)
 
 


### PR DESCRIPTION
Related to #217.

Since we're trying to move to using black on push, I've been running black locally as well before commits. 
It keeps reformatting these files every time and I'm getting tired of rolling them back.
The changes are minimal so they shouldn't pollute the history too much.