### PR TITLE
Provide session summary modal when browsing session history

### DIFF
--- a/src/visiomode/webpanel/static/js/history.js
+++ b/src/visiomode/webpanel/static/js/history.js
@@ -1,6 +1,7 @@
 /*
  * This file is part of visiomode.
  * Copyright (c) 2023 Constantinos Eleftheriou <Constantinos.Eleftheriou@ed.ac.uk>
+ * Copyright (c) 2024 Olivier Delree <odelree@ed.ac.uk>
  * Distributed under the terms of the MIT Licence.
  */
 
@@ -23,9 +24,7 @@ fetch("/api/history")
             let protocol = row.insertCell(2);
             protocol.innerHTML = session.protocol;
             let downloadButton = row.insertCell(3);
-            btn = document.createElement('input');
             downloadButton.innerHTML = `
-            <div class="dropdown">
                 <button
                     class="btn btn-primary btn-sm dropdown-toggle"
                     type="button" id="dropdownMenuButton" data-toggle="dropdown"
@@ -37,7 +36,6 @@ fetch("/api/history")
                     <a class="dropdown-item" href="/api/download/csv/${session.fname}">CSV</a>
                     <a class="dropdown-item" href="/api/download/nwb/${session.fname}">NWB</a>
                 </div>
-            </div>
             `;
         });
     });

--- a/src/visiomode/webpanel/static/js/history.js
+++ b/src/visiomode/webpanel/static/js/history.js
@@ -17,6 +17,7 @@ fetch("/api/history")
         sessions.forEach(session => {
             console.log(session.animal_id)
             let row = sessionsTableData.insertRow();
+            row.style.cssText = "cursor: pointer;";
             let date = row.insertCell(0);
             date.innerHTML = session.date;
             let animal_id = row.insertCell(1);
@@ -37,5 +38,28 @@ fetch("/api/history")
                     <a class="dropdown-item" href="/api/download/nwb/${session.fname}">NWB</a>
                 </div>
             `;
+            let session_id = row.insertCell(-1);
+            session_id.innerHTML = session.session_id;
+            row.cells[4].classList.add("d-none");  // Don't display this column
         });
     });
+
+let table = document.getElementById("sessionsTableData");
+
+table.onclick = async function (event) {
+    let session_id = event.target.closest("tr").cells[event.target.parentNode.cells.length - 1].innerHTML;
+    let session = await fetch(`/api/history?session_id=${session_id}`)
+        .then((response) => response.json())
+        .then((data) => data.session);
+
+    $("#viewSession").modal();
+
+    document.getElementById("animal-id").value = session?.animal_id ?? "";
+    document.getElementById("duration").value = session?.duration ?? "";
+    document.getElementById("experiment-id").value = session?.experiment ?? "";
+    document.getElementById("experimenter-name").value = session?.experimenter_name ?? "";
+    document.getElementById("protocol").value = session?.protocol ?? "";
+    document.getElementById("timestamp").value = session?.timestamp ?? "";
+    document.getElementById("trial-count").value = session?.trials?.length ?? "";
+    document.getElementById("notes").value = session?.notes ?? "";
+}

--- a/src/visiomode/webpanel/templates/history.html
+++ b/src/visiomode/webpanel/templates/history.html
@@ -27,66 +27,80 @@
 
     <div class="modal fade" id="viewSession" tabindex="-1" role="dialog" aria-labelledby="viewSessionTitle"
          aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-dialog modal-dialog-centered modal-xl" role="document">
             <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="viewSessionLongTitle">Session details</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-                <div class="modal-body">
-                    <form>
-                        <div class="form-group row">
-                            <label for="animal-id" class="col-sm-4 col-form-label">Animal ID</label>
-                            <div class="col-sm-7">
-                                <input type="text" class="form-control" id="animal-id" readonly>
-                            </div>
+                <div class="row">
+                    <div class="col">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="viewSessionLongTitle">Session details</h5>
                         </div>
-                        <div class="form-group row">
-                            <label for="duration" class="col-sm-4 col-form-label">Duration (mins)</label>
-                            <div class="col-sm-7">
-                                <input type="text" class="form-control" id="duration" readonly>
-                            </div>
-                        </div>
-                        <div class="form-group row">
-                            <label for="experiment-id" class="col-sm-4 col-form-label">Experiment ID</label>
-                            <div class="col-sm-7">
-                                <input type="text" class="form-control" id="experiment-id" readonly>
-                            </div>
-                        </div>
-                        <div class="form-group row align-items-center">
-                            <label for="experimenter-name" class="col-sm-4 col-form-label">Experimenter</label>
-                            <div class="col-sm-7">
-                                <input type="text" class="form-control" id="experimenter-name" readonly>
-                            </div>
-                        </div>
-                        <div class="form-group row">
-                            <label for="protocol" class="col-sm-4 col-form-label">Protocol</label>
-                            <div class="col-sm-7">
-                                <input type="text" class="form-control" id="protocol" readonly>
-                            </div>
-                        </div>
-                        <div class="form-group row">
-                            <label for="timestamp" class="col-sm-4 col-form-label">Timestamp</label>
-                            <div class="col-sm-7">
-                                <input type="text" class="form-control" id="timestamp" readonly>
-                            </div>
-                        </div>
-                        <div class="form-group row">
-                            <label for="trial-count" class="col-sm-4 col-form-label">Trial count</label>
-                            <div class="col-sm-7">
-                                <input type="text" class="form-control" id="trial-count" readonly>
-                            </div>
-                        </div>
-                        <div class="form-group row align-items-top">
-                            <label for="notes" class="col-sm-4 col-form-label">Notes</label>
-                            <div class="col-sm-7 input-sm-10">
+                        <div class="modal-body">
+                            <form>
+                                <div class="form-group row">
+                                    <label for="animal-id" class="col-sm-4 col-form-label">Animal ID</label>
+                                    <div class="col-sm-7">
+                                        <input type="text" class="form-control" id="animal-id" readonly>
+                                    </div>
+                                </div>
+                                <div class="form-group row">
+                                    <label for="duration" class="col-sm-4 col-form-label">Duration (mins)</label>
+                                    <div class="col-sm-7">
+                                        <input type="text" class="form-control" id="duration" readonly>
+                                    </div>
+                                </div>
+                                <div class="form-group row">
+                                    <label for="experiment-id" class="col-sm-4 col-form-label">Experiment ID</label>
+                                    <div class="col-sm-7">
+                                        <input type="text" class="form-control" id="experiment-id" readonly>
+                                    </div>
+                                </div>
+                                <div class="form-group row align-items-center">
+                                    <label for="experimenter-name" class="col-sm-4 col-form-label">Experimenter</label>
+                                    <div class="col-sm-7">
+                                        <input type="text" class="form-control" id="experimenter-name" readonly>
+                                    </div>
+                                </div>
+                                <div class="form-group row">
+                                    <label for="protocol" class="col-sm-4 col-form-label">Protocol</label>
+                                    <div class="col-sm-7">
+                                        <input type="text" class="form-control" id="protocol" readonly>
+                                    </div>
+                                </div>
+                                <div class="form-group row">
+                                    <label for="timestamp" class="col-sm-4 col-form-label">Timestamp</label>
+                                    <div class="col-sm-7">
+                                        <input type="text" class="form-control" id="timestamp" readonly>
+                                    </div>
+                                </div>
+                                <div class="form-group row">
+                                    <label for="trial-count" class="col-sm-4 col-form-label">Trial count</label>
+                                    <div class="col-sm-7">
+                                        <input type="text" class="form-control" id="trial-count" readonly>
+                                    </div>
+                                </div>
+                                <div class="form-group row align-items-top">
+                                    <label for="notes" class="col-sm-4 col-form-label">Notes</label>
+                                    <div class="col-sm-7 input-sm-10">
                                 <textarea rows="8" style="height:100%; resize: none;" type="text" class="form-control"
                                           id="notes" readonly></textarea>
+                                    </div>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="modal-header">
+                            <h5 class="modal-title">Overview</h5>
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                <span aria-hidden="true">&times;</span>
+                            </button>
+                        </div>
+                        <div class="modal-body">
+                            <div id="chart-area">
+                                <canvas id="trialsChart"></canvas>
                             </div>
                         </div>
-                    </form>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/visiomode/webpanel/templates/history.html
+++ b/src/visiomode/webpanel/templates/history.html
@@ -9,18 +9,85 @@
         </div>
         <div class="card-body">
             <div class="table-responsive">
-                <table  class="table table-hover" id="sessionsTable">
+                <table class="table table-hover" id="sessionsTable">
                     <thead>
-                        <tr>
-                            <th>Date</th>
-                            <th>Animal ID</th>
-                            <th>Protocol</th>
-                            <th>Session Data</th>
-                        </tr>
+                    <tr>
+                        <th>Date</th>
+                        <th>Animal ID</th>
+                        <th>Protocol</th>
+                        <th>Session Data</th>
+                        <th class="d-none">Session ID</th>
+                    </tr>
                     </thead>
-
-                    <tbody id="sessionsTableData"a></tbody>
+                    <tbody id="sessionsTableData"></tbody>
                 </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal fade" id="viewSession" tabindex="-1" role="dialog" aria-labelledby="viewSessionTitle"
+         aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="viewSessionLongTitle">Session details</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <form>
+                        <div class="form-group row">
+                            <label for="animal-id" class="col-sm-4 col-form-label">Animal ID</label>
+                            <div class="col-sm-7">
+                                <input type="text" class="form-control" id="animal-id" readonly>
+                            </div>
+                        </div>
+                        <div class="form-group row">
+                            <label for="duration" class="col-sm-4 col-form-label">Duration (mins)</label>
+                            <div class="col-sm-7">
+                                <input type="text" class="form-control" id="duration" readonly>
+                            </div>
+                        </div>
+                        <div class="form-group row">
+                            <label for="experiment-id" class="col-sm-4 col-form-label">Experiment ID</label>
+                            <div class="col-sm-7">
+                                <input type="text" class="form-control" id="experiment-id" readonly>
+                            </div>
+                        </div>
+                        <div class="form-group row align-items-center">
+                            <label for="experimenter-name" class="col-sm-4 col-form-label">Experimenter</label>
+                            <div class="col-sm-7">
+                                <input type="text" class="form-control" id="experimenter-name" readonly>
+                            </div>
+                        </div>
+                        <div class="form-group row">
+                            <label for="protocol" class="col-sm-4 col-form-label">Protocol</label>
+                            <div class="col-sm-7">
+                                <input type="text" class="form-control" id="protocol" readonly>
+                            </div>
+                        </div>
+                        <div class="form-group row">
+                            <label for="timestamp" class="col-sm-4 col-form-label">Timestamp</label>
+                            <div class="col-sm-7">
+                                <input type="text" class="form-control" id="timestamp" readonly>
+                            </div>
+                        </div>
+                        <div class="form-group row">
+                            <label for="trial-count" class="col-sm-4 col-form-label">Trial count</label>
+                            <div class="col-sm-7">
+                                <input type="text" class="form-control" id="trial-count" readonly>
+                            </div>
+                        </div>
+                        <div class="form-group row align-items-top">
+                            <label for="notes" class="col-sm-4 col-form-label">Notes</label>
+                            <div class="col-sm-7 input-sm-10">
+                                <textarea rows="8" style="height:100%; resize: none;" type="text" class="form-control"
+                                          id="notes" readonly></textarea>
+                            </div>
+                        </div>
+                    </form>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Closes #182.

This PR provides the user the option to see more details about sessions in the history. By clicking on the relevant row in the table, they get a modal dialogue with two columns, the left one is a summary of the session metadata while the right one is a chart showing trials in the same format as is available from the main page while the session is running.

To power this summary modal, the GET method for the `HistoryAPI` has also bee modified to allow single sessions to be requested by ID (i.e., their filename without the extension).