### PR TITLE
Add deletion and updating capability to session history

### DIFF
--- a/src/visiomode/webpanel/__init__.py
+++ b/src/visiomode/webpanel/__init__.py
@@ -105,7 +105,9 @@ def create_app(action_q=None, log_q=None):
     )
 
     app.add_url_rule(
-        "/api/history", view_func=api.HistoryAPI.as_view("history_api"), methods=["GET"]
+        "/api/history",
+        view_func=api.HistoryAPI.as_view("history_api"),
+        methods=["GET", "POST"],
     )
 
     app.add_url_rule(

--- a/src/visiomode/webpanel/api.py
+++ b/src/visiomode/webpanel/api.py
@@ -118,6 +118,43 @@ class HistoryAPI(flask.views.MethodView):
                         )
             return {"sessions": sessions}
 
+    def post(self):
+        success = False
+        return_code = 500
+
+        config = cfg.Config()
+
+        request = flask.request
+        if request.content_type != "application/json":
+            return_code = 415
+            return (
+                json.dumps({"success": success}),
+                return_code,
+                {"ContentType": "application/json"},
+            )
+
+        request_type = request.json.get("type")
+        request_data = request.json.get("data")
+
+        if request_type == "delete":
+            try:
+                session_id = request_data["sessionId"]
+                try:
+                    os.remove(f"{config.data_dir}{os.sep}{session_id}.json")
+                    success = True
+                    return_code = 200
+                except OSError or FileNotFoundError:
+                    logging.error(f"Could not delete session '{session_id}'.")
+                    return_code = 409
+            except KeyError:
+                logging.error("Malformed request data for request type 'DELETE'.")
+
+        return (
+            json.dumps({"success": success}),
+            return_code,
+            {"ContentType": "application/json"},
+        )
+
 
 class DownloadAPI(flask.views.MethodView):
     """Download session data in whatever format the user wants."""

--- a/src/visiomode/webpanel/api.py
+++ b/src/visiomode/webpanel/api.py
@@ -148,6 +148,32 @@ class HistoryAPI(flask.views.MethodView):
                     return_code = 409
             except KeyError:
                 logging.error("Malformed request data for request type 'DELETE'.")
+        elif request_type == "update":
+            try:
+                session_id = request_data["sessionId"]
+                updated_session_data = request_data["updatedSessionData"]
+
+                try:
+                    session_path = f"{config.data_dir}{os.sep}{session_id}.json"
+                    with open(session_path) as handle:
+                        session_data = json.load(handle)
+
+                    # Currently only notes can be updated
+                    session_data["notes"] = updated_session_data["notes"]
+
+                    with open(session_path, "w") as handle:
+                        json.dump(session_data, handle)
+
+                    success = True
+                    return_code = 200
+                except OSError or FileNotFoundError:
+                    logging.error(f"Error handling session'{session_id}'.")
+                    return_code = 409
+                except KeyError:
+                    logging.error(f"Error updating requested session attributes.")
+                    return_code = 400
+            except KeyError:
+                logging.error("Malformed request data for request type 'UPDATE'.")
 
         return (
             json.dumps({"success": success}),

--- a/src/visiomode/webpanel/static/js/history.js
+++ b/src/visiomode/webpanel/static/js/history.js
@@ -1,6 +1,7 @@
 /*
  * This file is part of visiomode.
  * Copyright (c) 2023 Constantinos Eleftheriou <Constantinos.Eleftheriou@ed.ac.uk>
+ * Copyright (c) 2024 Olivier Delree <odelree@ed.ac.uk>
  * Distributed under the terms of the MIT Licence.
  */
 
@@ -23,9 +24,7 @@ fetch("/api/history")
             let protocol = row.insertCell(2);
             protocol.innerHTML = session.protocol;
             let downloadButton = row.insertCell(3);
-            btn = document.createElement('input');
             downloadButton.innerHTML = `
-            <div class="dropdown">
                 <button
                     class="btn btn-primary btn-sm dropdown-toggle"
                     type="button" id="dropdownMenuButton" data-toggle="dropdown"
@@ -37,7 +36,6 @@ fetch("/api/history")
                     <a class="dropdown-item" href="/api/download/csv/${session.fname}">CSV</a>
                     <a class="dropdown-item" href="/api/download/nwb/${session.fname}">NWB</a>
                 </div>
-            </div>
             `;
         });
     });

--- a/src/visiomode/webpanel/static/js/history.js
+++ b/src/visiomode/webpanel/static/js/history.js
@@ -17,6 +17,7 @@ fetch("/api/history")
         sessions.forEach(session => {
             console.log(session.animal_id)
             let row = sessionsTableData.insertRow();
+            row.style.cssText = "cursor: pointer;";
             let date = row.insertCell(0);
             date.innerHTML = session.date;
             let animal_id = row.insertCell(1);
@@ -37,5 +38,28 @@ fetch("/api/history")
                     <a class="dropdown-item" href="/api/download/nwb/${session.fname}">NWB</a>
                 </div>
             `;
+            let session_id = row.insertCell(-1);
+            session_id.innerHTML = session.session_id;
+            row.cells[4].classList.add("d-none");  // Don't display this column
         });
     });
+
+let table = document.getElementById("sessionsTableData");
+
+table.onclick = async function (event) {
+    let session_id = event.target.closest("tr").cells[event.target.parentNode.cells.length - 1].innerHTML;
+    let session = await fetch(`/api/history?session_id=${session_id}`)
+        .then((response) => response.json())
+        .then((data) => data.session);
+
+    $("#viewSession").modal();
+
+    document.getElementById("animal-id").value = session?.animal_id ?? "";
+    document.getElementById("duration").value = session?.duration ?? "";
+    document.getElementById("experiment-id").value = session?.experiment ?? "";
+    document.getElementById("experimenter-name").value = session?.experimenter_name ?? "";
+    document.getElementById("protocol").value = session?.protocol ?? "";
+    document.getElementById("timestamp").value = session?.timestamp ?? "";
+    document.getElementById("trial-count").value = session?.trials?.length ?? "";
+    document.getElementById("notes").value = session?.notes ?? "";
+}

--- a/src/visiomode/webpanel/static/js/history.js
+++ b/src/visiomode/webpanel/static/js/history.js
@@ -46,13 +46,15 @@ fetch("/api/history")
 
 let table = document.getElementById("sessionsTableData");
 
+let currentSessionId;
+
 const canvasContext = document.getElementById("trialsChart");
 let trialsChart;
 let currentChartSessionId;
 
 table.onclick = async function (event) {
-    let session_id = event.target.closest("tr").cells[event.target.parentNode.cells.length - 1].innerHTML;
-    let session = await fetch(`/api/history?session_id=${session_id}`)
+    currentSessionId = event.target.closest("tr").cells[event.target.parentNode.cells.length - 1].innerHTML;
+    let session = await fetch(`/api/history?session_id=${currentSessionId}`)
         .then((response) => response.json())
         .then((data) => data.session);
 
@@ -68,7 +70,7 @@ table.onclick = async function (event) {
     document.getElementById("notes").value = session?.notes ?? "";
 
     // Avoid unnecessarily redrawing the chart when reopening the same modal
-    if (session_id !== currentChartSessionId) {
+    if (currentSessionId !== currentChartSessionId) {
         trialsChart?.destroy();
 
         if (session?.trials?.length) {
@@ -82,7 +84,7 @@ table.onclick = async function (event) {
             trialsChart = createChart(canvasContext, []);
         }
 
-        currentChartSessionId = session_id;
+        currentChartSessionId = currentSessionId;
     }
 }
 
@@ -112,5 +114,66 @@ function createChart(canvas, session_data) {
                 },
             }
         },
+    });
+}
+
+let deleteSessionDataSpan = document.getElementById("deleteSessionDataSpan");
+let deleteSessionDataButton = document.getElementById("deleteSessionDataButton");
+let buttonAnimation;
+let buttonAnimationDuration = 1000;
+
+function generateLoadingButtonKeyFrames() {
+    let keyFrames = [];
+    for (let i = 0; i <= 100; i++) {
+        keyFrames.push({background: `linear-gradient(to right, #bb2d3b 0%, #bb2d3b ${i}%, #DC3545 ${i}%, #DC3545 100%)`});
+    }
+    return keyFrames;
+}
+
+deleteSessionDataSpan.onmouseover = () => {
+    // Create the animation if it's the first hover event
+    if (!buttonAnimation) {
+        buttonAnimation = deleteSessionDataButton.animate(generateLoadingButtonKeyFrames(), {
+            duration: buttonAnimationDuration,
+        });
+        buttonAnimation.onfinish = () => {
+            // `onfinish` triggers when the animation gets back to the start
+            // if the user stops hovering, so only enable the button if it
+            // reached the "forward end"
+            if (buttonAnimation.currentTime === buttonAnimationDuration) {
+                deleteSessionDataButton.removeAttribute("disabled");
+            }
+        };
+    }
+    buttonAnimation.playbackRate = 1;  // Resume animation forward
+}
+deleteSessionDataSpan.onmouseout = () => {
+    deleteSessionDataButton.setAttribute("disabled", "");
+    buttonAnimation.playbackRate = -2;  // Reverse animation at twice the speed
+}
+
+deleteSessionDataButton.onclick = () => {
+    deleteSessionData(currentSessionId);
+    // Reset the animation
+    buttonAnimation.playbackRate = -1;
+    buttonAnimation.finish();
+};
+
+function deleteSessionData(sessionId) {
+    $.ajax({
+        type: "POST",
+        url: "/api/history",
+        data: JSON.stringify({
+            type: "delete",
+            data: {sessionId},
+        }),
+        dataType: "json",
+        contentType: "application/json",
+        success: function () {
+            // Close all the modals
+            $('.modal').modal('hide');
+            // Remove the row for the deleted session
+            $("#sessionsTableData").find("td:contains('" + sessionId + "')").closest("tr").remove();
+        }
     });
 }

--- a/src/visiomode/webpanel/static/js/history.js
+++ b/src/visiomode/webpanel/static/js/history.js
@@ -177,3 +177,30 @@ function deleteSessionData(sessionId) {
         }
     });
 }
+
+let summaryModal = document.getElementById("viewSession");
+summaryModal.onshown = () => {
+    document.getElementById("notes").focus();
+}
+
+function updateSessionData(sessionId, updatedSessionData) {
+    $.ajax({
+        type: "POST",
+        url: "/api/history",
+        data: JSON.stringify({
+            type: "update",
+            data: {sessionId, updatedSessionData},
+        }),
+        dataType: "json",
+        contentType: "application/json",
+    });
+}
+
+let updateSessionButton = document.getElementById("updateButton");
+updateSessionButton.onclick = () => {
+    let newData = {
+        "notes": document.getElementById("notes").value,
+    }
+
+    updateSessionData(currentSessionId, newData);
+}

--- a/src/visiomode/webpanel/templates/history.html
+++ b/src/visiomode/webpanel/templates/history.html
@@ -29,78 +29,107 @@
          aria-hidden="true">
         <div class="modal-dialog modal-dialog-centered modal-xl" role="document">
             <div class="modal-content">
-                <div class="row">
-                    <div class="col">
-                        <div class="modal-header">
-                            <h5 class="modal-title" id="viewSessionLongTitle">Session details</h5>
+                <div class="container">
+                    <div class="row">
+                        <div class="col">
+                            <div class="modal-header">
+                                <h5 class="modal-title" id="viewSessionLongTitle">Session details</h5>
+                            </div>
+                            <div class="modal-body">
+                                <form>
+                                    <div class="form-group row">
+                                        <label for="animal-id" class="col-sm-4 col-form-label">Animal ID</label>
+                                        <div class="col-sm-7">
+                                            <input type="text" class="form-control" id="animal-id" readonly>
+                                        </div>
+                                    </div>
+                                    <div class="form-group row">
+                                        <label for="duration" class="col-sm-4 col-form-label">Duration (mins)</label>
+                                        <div class="col-sm-7">
+                                            <input type="text" class="form-control" id="duration" readonly>
+                                        </div>
+                                    </div>
+                                    <div class="form-group row">
+                                        <label for="experiment-id" class="col-sm-4 col-form-label">Experiment ID</label>
+                                        <div class="col-sm-7">
+                                            <input type="text" class="form-control" id="experiment-id" readonly>
+                                        </div>
+                                    </div>
+                                    <div class="form-group row align-items-center">
+                                        <label for="experimenter-name" class="col-sm-4 col-form-label">Experimenter</label>
+                                        <div class="col-sm-7">
+                                            <input type="text" class="form-control" id="experimenter-name" readonly>
+                                        </div>
+                                    </div>
+                                    <div class="form-group row">
+                                        <label for="protocol" class="col-sm-4 col-form-label">Protocol</label>
+                                        <div class="col-sm-7">
+                                            <input type="text" class="form-control" id="protocol" readonly>
+                                        </div>
+                                    </div>
+                                    <div class="form-group row">
+                                        <label for="timestamp" class="col-sm-4 col-form-label">Timestamp</label>
+                                        <div class="col-sm-7">
+                                            <input type="text" class="form-control" id="timestamp" readonly>
+                                        </div>
+                                    </div>
+                                    <div class="form-group row">
+                                        <label for="trial-count" class="col-sm-4 col-form-label">Trial count</label>
+                                        <div class="col-sm-7">
+                                            <input type="text" class="form-control" id="trial-count" readonly>
+                                        </div>
+                                    </div>
+                                    <div class="form-group row align-items-top">
+                                        <label for="notes" class="col-sm-4 col-form-label">Notes</label>
+                                        <div class="col-sm-7 input-sm-10">
+                                            <textarea rows="8" style="height:100%; resize: none;" type="text"
+                                                      class="form-control" id="notes" readonly></textarea>
+                                        </div>
+                                    </div>
+                                </form>
+                            </div>
                         </div>
-                        <div class="modal-body">
-                            <form>
-                                <div class="form-group row">
-                                    <label for="animal-id" class="col-sm-4 col-form-label">Animal ID</label>
-                                    <div class="col-sm-7">
-                                        <input type="text" class="form-control" id="animal-id" readonly>
-                                    </div>
+                        <div class="col">
+                            <div class="modal-header">
+                                <h5 class="modal-title">Overview</h5>
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                    <span aria-hidden="true">&times;</span>
+                                </button>
+                            </div>
+                            <div class="modal-body">
+                                <div id="chart-area">
+                                    <canvas id="trialsChart"></canvas>
                                 </div>
-                                <div class="form-group row">
-                                    <label for="duration" class="col-sm-4 col-form-label">Duration (mins)</label>
-                                    <div class="col-sm-7">
-                                        <input type="text" class="form-control" id="duration" readonly>
-                                    </div>
-                                </div>
-                                <div class="form-group row">
-                                    <label for="experiment-id" class="col-sm-4 col-form-label">Experiment ID</label>
-                                    <div class="col-sm-7">
-                                        <input type="text" class="form-control" id="experiment-id" readonly>
-                                    </div>
-                                </div>
-                                <div class="form-group row align-items-center">
-                                    <label for="experimenter-name" class="col-sm-4 col-form-label">Experimenter</label>
-                                    <div class="col-sm-7">
-                                        <input type="text" class="form-control" id="experimenter-name" readonly>
-                                    </div>
-                                </div>
-                                <div class="form-group row">
-                                    <label for="protocol" class="col-sm-4 col-form-label">Protocol</label>
-                                    <div class="col-sm-7">
-                                        <input type="text" class="form-control" id="protocol" readonly>
-                                    </div>
-                                </div>
-                                <div class="form-group row">
-                                    <label for="timestamp" class="col-sm-4 col-form-label">Timestamp</label>
-                                    <div class="col-sm-7">
-                                        <input type="text" class="form-control" id="timestamp" readonly>
-                                    </div>
-                                </div>
-                                <div class="form-group row">
-                                    <label for="trial-count" class="col-sm-4 col-form-label">Trial count</label>
-                                    <div class="col-sm-7">
-                                        <input type="text" class="form-control" id="trial-count" readonly>
-                                    </div>
-                                </div>
-                                <div class="form-group row align-items-top">
-                                    <label for="notes" class="col-sm-4 col-form-label">Notes</label>
-                                    <div class="col-sm-7 input-sm-10">
-                                <textarea rows="8" style="height:100%; resize: none;" type="text" class="form-control"
-                                          id="notes" readonly></textarea>
-                                    </div>
-                                </div>
-                            </form>
-                        </div>
-                    </div>
-                    <div class="col">
-                        <div class="modal-header">
-                            <h5 class="modal-title">Overview</h5>
-                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                                <span aria-hidden="true">&times;</span>
-                            </button>
-                        </div>
-                        <div class="modal-body">
-                            <div id="chart-area">
-                                <canvas id="trialsChart"></canvas>
                             </div>
                         </div>
                     </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                    <button type="button" class="btn btn-danger" data-toggle="modal" href="#confirmDeletion">Delete</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal fade" id="confirmDeletion" tabindex="-2" role="dialog" aria-labelledby="confirmDeletionTitle"
+         aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Delete session?</h5>
+                </div>
+                <div class="modal-body">
+                    <p>Deleting session data will remove it from the filesystem.</p>
+                    <h6 class="text-danger"><b>⚠ Warning: this action cannot be undone. ⚠</b></h6>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                    <span id="deleteSessionDataSpan">
+                        <button class="btn btn-danger" id="deleteSessionDataButton" data-dismiss="modal" disabled>
+                            I am aware, delete it
+                        </button>
+                    </span>
                 </div>
             </div>
         </div>

--- a/src/visiomode/webpanel/templates/history.html
+++ b/src/visiomode/webpanel/templates/history.html
@@ -27,66 +27,80 @@
 
     <div class="modal fade" id="viewSession" tabindex="-1" role="dialog" aria-labelledby="viewSessionTitle"
          aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-dialog modal-dialog-centered modal-xl" role="document">
             <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="viewSessionLongTitle">Session details</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                        <span aria-hidden="true">&times;</span>
-                    </button>
-                </div>
-                <div class="modal-body">
-                    <form>
-                        <div class="form-group row">
-                            <label for="animal-id" class="col-sm-4 col-form-label">Animal ID</label>
-                            <div class="col-sm-7">
-                                <input type="text" class="form-control" id="animal-id" readonly>
-                            </div>
+                <div class="row">
+                    <div class="col">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="viewSessionLongTitle">Session details</h5>
                         </div>
-                        <div class="form-group row">
-                            <label for="duration" class="col-sm-4 col-form-label">Duration (mins)</label>
-                            <div class="col-sm-7">
-                                <input type="text" class="form-control" id="duration" readonly>
-                            </div>
-                        </div>
-                        <div class="form-group row">
-                            <label for="experiment-id" class="col-sm-4 col-form-label">Experiment ID</label>
-                            <div class="col-sm-7">
-                                <input type="text" class="form-control" id="experiment-id" readonly>
-                            </div>
-                        </div>
-                        <div class="form-group row align-items-center">
-                            <label for="experimenter-name" class="col-sm-4 col-form-label">Experimenter</label>
-                            <div class="col-sm-7">
-                                <input type="text" class="form-control" id="experimenter-name" readonly>
-                            </div>
-                        </div>
-                        <div class="form-group row">
-                            <label for="protocol" class="col-sm-4 col-form-label">Protocol</label>
-                            <div class="col-sm-7">
-                                <input type="text" class="form-control" id="protocol" readonly>
-                            </div>
-                        </div>
-                        <div class="form-group row">
-                            <label for="timestamp" class="col-sm-4 col-form-label">Timestamp</label>
-                            <div class="col-sm-7">
-                                <input type="text" class="form-control" id="timestamp" readonly>
-                            </div>
-                        </div>
-                        <div class="form-group row">
-                            <label for="trial-count" class="col-sm-4 col-form-label">Trial count</label>
-                            <div class="col-sm-7">
-                                <input type="text" class="form-control" id="trial-count" readonly>
-                            </div>
-                        </div>
-                        <div class="form-group row align-items-top">
-                            <label for="notes" class="col-sm-4 col-form-label">Notes</label>
-                            <div class="col-sm-7 input-sm-10">
+                        <div class="modal-body">
+                            <form>
+                                <div class="form-group row">
+                                    <label for="animal-id" class="col-sm-4 col-form-label">Animal ID</label>
+                                    <div class="col-sm-7">
+                                        <input type="text" class="form-control" id="animal-id" readonly>
+                                    </div>
+                                </div>
+                                <div class="form-group row">
+                                    <label for="duration" class="col-sm-4 col-form-label">Duration (mins)</label>
+                                    <div class="col-sm-7">
+                                        <input type="text" class="form-control" id="duration" readonly>
+                                    </div>
+                                </div>
+                                <div class="form-group row">
+                                    <label for="experiment-id" class="col-sm-4 col-form-label">Experiment ID</label>
+                                    <div class="col-sm-7">
+                                        <input type="text" class="form-control" id="experiment-id" readonly>
+                                    </div>
+                                </div>
+                                <div class="form-group row align-items-center">
+                                    <label for="experimenter-name" class="col-sm-4 col-form-label">Experimenter</label>
+                                    <div class="col-sm-7">
+                                        <input type="text" class="form-control" id="experimenter-name" readonly>
+                                    </div>
+                                </div>
+                                <div class="form-group row">
+                                    <label for="protocol" class="col-sm-4 col-form-label">Protocol</label>
+                                    <div class="col-sm-7">
+                                        <input type="text" class="form-control" id="protocol" readonly>
+                                    </div>
+                                </div>
+                                <div class="form-group row">
+                                    <label for="timestamp" class="col-sm-4 col-form-label">Timestamp</label>
+                                    <div class="col-sm-7">
+                                        <input type="text" class="form-control" id="timestamp" readonly>
+                                    </div>
+                                </div>
+                                <div class="form-group row">
+                                    <label for="trial-count" class="col-sm-4 col-form-label">Trial count</label>
+                                    <div class="col-sm-7">
+                                        <input type="text" class="form-control" id="trial-count" readonly>
+                                    </div>
+                                </div>
+                                <div class="form-group row align-items-top">
+                                    <label for="notes" class="col-sm-4 col-form-label">Notes</label>
+                                    <div class="col-sm-7 input-sm-10">
                                 <textarea rows="8" style="height:100%; resize: none;" type="text" class="form-control"
                                           id="notes" readonly></textarea>
+                                    </div>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                    <div class="col">
+                        <div class="modal-header">
+                            <h5 class="modal-title">Overview</h5>
+                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                <span aria-hidden="true">&times;</span>
+                            </button>
+                        </div>
+                        <div class="modal-body">
+                            <div id="chart-area">
+                                <canvas id="trialsChart"></canvas>
                             </div>
                         </div>
-                    </form>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/visiomode/webpanel/templates/history.html
+++ b/src/visiomode/webpanel/templates/history.html
@@ -83,7 +83,7 @@
                                         <label for="notes" class="col-sm-4 col-form-label">Notes</label>
                                         <div class="col-sm-7 input-sm-10">
                                             <textarea rows="8" style="height:100%; resize: none;" type="text"
-                                                      class="form-control" id="notes" readonly></textarea>
+                                                      class="form-control" id="notes"></textarea>
                                         </div>
                                     </div>
                                 </form>
@@ -107,6 +107,7 @@
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
                     <button type="button" class="btn btn-danger" data-toggle="modal" href="#confirmDeletion">Delete</button>
+                    <button type="button" class="btn btn-primary" data-dismiss="modal" id="updateButton">Update</button>
                 </div>
             </div>
         </div>

--- a/src/visiomode/webpanel/templates/history.html
+++ b/src/visiomode/webpanel/templates/history.html
@@ -9,18 +9,85 @@
         </div>
         <div class="card-body">
             <div class="table-responsive">
-                <table  class="table table-hover" id="sessionsTable">
+                <table class="table table-hover" id="sessionsTable">
                     <thead>
-                        <tr>
-                            <th>Date</th>
-                            <th>Animal ID</th>
-                            <th>Protocol</th>
-                            <th>Session Data</th>
-                        </tr>
+                    <tr>
+                        <th>Date</th>
+                        <th>Animal ID</th>
+                        <th>Protocol</th>
+                        <th>Session Data</th>
+                        <th class="d-none">Session ID</th>
+                    </tr>
                     </thead>
-
-                    <tbody id="sessionsTableData"a></tbody>
+                    <tbody id="sessionsTableData"></tbody>
                 </table>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal fade" id="viewSession" tabindex="-1" role="dialog" aria-labelledby="viewSessionTitle"
+         aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="viewSessionLongTitle">Session details</h5>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <form>
+                        <div class="form-group row">
+                            <label for="animal-id" class="col-sm-4 col-form-label">Animal ID</label>
+                            <div class="col-sm-7">
+                                <input type="text" class="form-control" id="animal-id" readonly>
+                            </div>
+                        </div>
+                        <div class="form-group row">
+                            <label for="duration" class="col-sm-4 col-form-label">Duration (mins)</label>
+                            <div class="col-sm-7">
+                                <input type="text" class="form-control" id="duration" readonly>
+                            </div>
+                        </div>
+                        <div class="form-group row">
+                            <label for="experiment-id" class="col-sm-4 col-form-label">Experiment ID</label>
+                            <div class="col-sm-7">
+                                <input type="text" class="form-control" id="experiment-id" readonly>
+                            </div>
+                        </div>
+                        <div class="form-group row align-items-center">
+                            <label for="experimenter-name" class="col-sm-4 col-form-label">Experimenter</label>
+                            <div class="col-sm-7">
+                                <input type="text" class="form-control" id="experimenter-name" readonly>
+                            </div>
+                        </div>
+                        <div class="form-group row">
+                            <label for="protocol" class="col-sm-4 col-form-label">Protocol</label>
+                            <div class="col-sm-7">
+                                <input type="text" class="form-control" id="protocol" readonly>
+                            </div>
+                        </div>
+                        <div class="form-group row">
+                            <label for="timestamp" class="col-sm-4 col-form-label">Timestamp</label>
+                            <div class="col-sm-7">
+                                <input type="text" class="form-control" id="timestamp" readonly>
+                            </div>
+                        </div>
+                        <div class="form-group row">
+                            <label for="trial-count" class="col-sm-4 col-form-label">Trial count</label>
+                            <div class="col-sm-7">
+                                <input type="text" class="form-control" id="trial-count" readonly>
+                            </div>
+                        </div>
+                        <div class="form-group row align-items-top">
+                            <label for="notes" class="col-sm-4 col-form-label">Notes</label>
+                            <div class="col-sm-7 input-sm-10">
+                                <textarea rows="8" style="height:100%; resize: none;" type="text" class="form-control"
+                                          id="notes" readonly></textarea>
+                            </div>
+                        </div>
+                    </form>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Depends on #222.

This is a follow-up to #222. It adds the ability to delete a single session from its summary modal as well as to update the "notes" section of a session.

Note that review should focus on #222 first before merging this PR.