### PR TITLE
Delete config file when deleting app data

### DIFF
--- a/src/visiomode/config.py
+++ b/src/visiomode/config.py
@@ -160,6 +160,7 @@ def clear_db():
 def clear_data():
     """Clears the data directory."""
     shutil.rmtree(Config().data_dir, ignore_errors=True)
+    shutil.rmtree(Config().config_path, ignore_errors=True)
 
     # Create new config file with default settings
     Config._instance = None


### PR DESCRIPTION
In PR #198, `config.clear_data()` does delete the data directory but omits the config file itself. According to the interface (and the rest of the function body), it should also remove the config file so that the config can be reset to its default value.